### PR TITLE
Support for Obj-C

### DIFF
--- a/JonContextMenu/JonContextMenu/JonContextMenu.swift
+++ b/JonContextMenu/JonContextMenu/JonContextMenu.swift
@@ -10,7 +10,7 @@ import UIKit
 import Foundation
 import UIKit.UIGestureRecognizerSubclass
 
-public protocol JonContextMenuDelegate {
+@objc public protocol JonContextMenuDelegate {
     func menuOpened()
     func menuClosed()
     func menuItemWasSelected(item:JonItem)
@@ -18,7 +18,7 @@ public protocol JonContextMenuDelegate {
     func menuItemWasDeactivated(item:JonItem)
 }
 
-open class JonContextMenu{
+@objc open class JonContextMenu:NSObject{
     
     /// The items to be displayed
     var items:[JonItem] = []
@@ -56,77 +56,77 @@ open class JonContextMenu{
     /// The view selected by the user
     var highlightedView:UIView!
     
-    public init(){
-        
+    override public init(){
+        super.init()
     }
     
     /// Sets the items for the JonContextMenu
-    open func setItems(_ items: [JonItem])->JonContextMenu{
+  @objc   open func setItems(_ items: [JonItem])->JonContextMenu{
         self.items = items
         return self
     }
     
     /// Sets the delegate for the JonContextMenu
-    open func setDelegate(_ delegate: JonContextMenuDelegate?)->JonContextMenu{
+  @objc  open func setDelegate(_ delegate: JonContextMenuDelegate?)->JonContextMenu{
         self.delegate = delegate
         return self
     }
     
     /// Sets the background of the JonContextMenu
-    open func setBackgroundColorTo(_ backgroundColor: UIColor, withAlpha alpha:CGFloat = 0.9)->JonContextMenu{
+    @objc open func setBackgroundColorTo(_ backgroundColor: UIColor, withAlpha alpha:CGFloat = 0.9)->JonContextMenu{
         self.backgroundAlpha = alpha
         self.backgroundColor = backgroundColor
         return self
     }
     
     /// Sets the colour of the buttons for when there is no interaction
-    open func setItemsDefaultColorTo(_ colour: UIColor)->JonContextMenu{
+    @objc open func setItemsDefaultColorTo(_ colour: UIColor)->JonContextMenu{
         self.buttonsDefaultColor = colour
         return self
     }
     
     /// Sets the colour of the buttons for when there is interaction
-    open func setItemsActiveColorTo(_ colour: UIColor)->JonContextMenu{
+    @objc open func setItemsActiveColorTo(_ colour: UIColor)->JonContextMenu{
         self.buttonsActiveColor = colour
         return self
     }
     
     /// Sets the colour of the icons for when there is no interaction
-    open func setIconsDefaultColorTo(_ colour: UIColor?)->JonContextMenu{
+    @objc open func setIconsDefaultColorTo(_ colour: UIColor?)->JonContextMenu{
         self.iconsDefaultColor = colour
         return self
     }
     
     /// Sets the colour of the icons for when there is interaction
-    open func setIconsActiveColorTo(_ colour: UIColor?)->JonContextMenu{
+    @objc open func setIconsActiveColorTo(_ colour: UIColor?)->JonContextMenu{
         self.iconsActiveColor = colour
         return self
     }
     
     /// Sets the colour of the JonContextMenu items title
-    open func setItemsTitleColorTo(_ color: UIColor)->JonContextMenu{
+    @objc open func setItemsTitleColorTo(_ color: UIColor)->JonContextMenu{
         self.itemsTitleColor = color
         return self
     }
     
     /// Sets the size of the JonContextMenu items title
-    open func setItemsTitleSizeTo(_ size: CGFloat)->JonContextMenu{
+    @objc open func setItemsTitleSizeTo(_ size: CGFloat)->JonContextMenu{
         self.itemsTitleSize = size
         return self
     }
     
     /// Sets the colour of the JonContextMenu touch point
-    open func setTouchPointColorTo(_ color: UIColor)->JonContextMenu{
+    @objc open func setTouchPointColorTo(_ color: UIColor)->JonContextMenu{
         self.touchPointColor = color
         return self
     }
     
     /// Builds the JonContextMenu
-    open func build()->Builder{
+    @objc open func build()->Builder{
         return Builder(self)
     }
     
-    open class Builder:UILongPressGestureRecognizer{
+    @objc open class Builder:UILongPressGestureRecognizer{
         
         /// The wrapper for the JonContextMenu
         private var window:UIWindow!
@@ -143,7 +143,7 @@ open class JonContextMenu{
         /// Indicates if there is a menu item active
         private var isItemActive = false
         
-        init(_ properties:JonContextMenu){
+      @objc  init(_ properties:JonContextMenu){
             super.init(target: nil, action: nil)
             guard let window = UIApplication.shared.keyWindow else{
                 fatalError("No access to UIApplication Window")

--- a/JonContextMenu/JonContextMenu/JonItem.swift
+++ b/JonContextMenu/JonContextMenu/JonItem.swift
@@ -9,19 +9,27 @@
 import UIKit
 import Foundation
 
-open class JonItem:UIView {
+@objc open class JonItem:UIView {
     
     private static let vWidth  = 45
     private static let vHeight = 45
     
     /// The id of the item
-    open var id:Int?
+    private var _id:Int?
+    @objc public var id: NSNumber? {
+    get {
+      return _id as NSNumber?
+    }
+    @objc set(newNumber) {
+      _id = newNumber?.intValue
+    }
+  }
     
     /// The title of the item
-    open var title:String = ""
+    @objc open var title:String = ""
     
     /// The data that the item holds
-    open var data:Any?
+    @objc open var data:Any?
     
     /// The angle that the item will appear
     var angle: CGFloat = 0
@@ -77,9 +85,9 @@ open class JonItem:UIView {
         ])
     }
     
-    public init(id:Int, title:String, icon:UIImage?, data:Any?=nil){
+  @objc  public init(id:NSNumber, title:String, icon:UIImage?, data:Any?=nil){
         super.init(frame: CGRect(x: 0, y: 0, width: JonItem.vWidth, height: JonItem.vHeight))
-        self.id         = id
+        _id         = id.intValue
         self.data       = data
         self.title      = title
         self.icon.image = icon
@@ -96,7 +104,7 @@ open class JonItem:UIView {
     }
     
     /// Changes the colours of the button and the icon
-    func setItemColorTo(_ itemColour:UIColor, iconColor:UIColor?=nil){
+    @objc func setItemColorTo(_ itemColour:UIColor, iconColor:UIColor?=nil){
         if let colour = iconColor{
             let templateImage = icon.image?.withRenderingMode(.alwaysTemplate)
             icon.image     = templateImage


### PR DESCRIPTION
Hi,

thanks for your nice menu.
I tried using it with Objective-C, but the interface definitions did not allow the creation of the bridging header due to missing `@objC`-tagging.
I've added them and had to change the way the id property of the item is implemented (switched to `NSNumber` instead of` int`). You should check this as I'm a swift beginner coming from Objective-C.
Now the menu does integrate fine (in my scenario) in my objective-C project (latest Xcode beta).
What is not working well is the behaviour on the iPad (Overlay on the whole screen when opening the menu, text being shown based on the windows bounds, not close to the menu item selected).
Maybe you could have a look into this, my swift is still a bit basic.

Regards
Oggerschummer